### PR TITLE
Fix the TypeError: expected CUDA (got CPU) error

### DIFF
--- a/src/rembg/u2net/detect.py
+++ b/src/rembg/u2net/detect.py
@@ -107,7 +107,7 @@ def predict(net, item):
     with torch.no_grad():
 
         if torch.cuda.is_available():
-            inputs_test = torch.cuda.FloatTensor(sample["image"].unsqueeze(0).float())
+            inputs_test = torch.cuda.FloatTensor(sample["image"].unsqueeze(0).cuda().float())
         else:
             inputs_test = torch.FloatTensor(sample["image"].unsqueeze(0).float())
 


### PR DESCRIPTION
I try this:
```
rembg -o test.png input.jpg
```

And got this error:
```
Traceback (most recent call last):
  File "/home/user/.local/bin/rembg", line 11, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.8/site-packages/rembg/cmd/cli.py", line 66, in main
    w(args.output, remove(r(args.input), args.model))
  File "/home/user/.local/lib/python3.8/site-packages/rembg/bg.py", line 19, in remove
    roi = detect.predict(model, np.array(img))
  File "/home/user/.local/lib/python3.8/site-packages/rembg/u2net/detect.py", line 110, in predict
    inputs_test = torch.cuda.FloatTensor(sample["image"].unsqueeze(0).float())
TypeError: expected CUDA (got CPU)
```

The error is because the model is on GPU while input image is on CPU. We have to make sure that they are both on GPU or CPU.

I modified the 110 line in [detect.py](https://github.com/danielgatis/rembg/blob/master/src/rembg/u2net/detect.py#L110) by adding the `.cuda()` method.

```python
if torch.cuda.is_available():
    inputs_test = torch.cuda.FloatTensor(sample["image"].unsqueeze(0).cuda().float())
 else:
    inputs_test = torch.FloatTensor(sample["image"].unsqueeze(0).float())
```

I suggest adding a new setting flag to choose between using GPU and CPU.

```
rembg -o test.png input.jpg --gpu 1
```