### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm==4.51.0
 requests==2.24.0
 scipy==1.5.4
 pymatting==1.1.1
+dataclasses==0.6


### PR DESCRIPTION
It will install the latest dataclasses of version 0.7 when installing torch.
But dataclasses of version 0.7 is not compatible with python3.8.
So force to use dataclasses 0.6