### PR TITLE
[bug fix] change image file detector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm==4.51.0
 requests==2.24.0
 scipy==1.5.4
 pymatting==1.1.1
+filetype=1.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ tqdm==4.51.0
 requests==2.24.0
 scipy==1.5.4
 pymatting==1.1.1
-filetype=1.0.7
+filetype==1.0.7

--- a/src/rembg/cmd/cli.py
+++ b/src/rembg/cmd/cli.py
@@ -2,6 +2,7 @@ import argparse
 import glob
 import imghdr
 import os
+import filetype
 from distutils.util import strtobool
 
 from ..bg import remove
@@ -90,7 +91,10 @@ def main():
                 full_paths += glob.glob(path + "/*")
 
         for fi in files:
-            if imghdr.what(fi) is None:
+            fi_type = filetype.guess(fi)
+            if fi_type is None:
+                continue
+            elif if_type.mime.find('image') < 0:
                 continue
 
             with open(fi, "rb") as input:

--- a/src/rembg/cmd/cli.py
+++ b/src/rembg/cmd/cli.py
@@ -1,6 +1,5 @@
 import argparse
 import glob
-import imghdr
 import os
 import filetype
 from distutils.util import strtobool


### PR DESCRIPTION
hi Daniel,

There is a bug to image type detection.

For example, this is a normal jpeg file and it could be removed background image by rembg successfully.

https://gd1.alicdn.com/imgextra/i1/840645308/O1CN01KtWy881p56tGmRU5a_!!840645308.jpg

This file will be filtered out by imghdr.what method, so I have changed to another image file detection method.

Thanks for your good and useful tool!
Jaric
