### PR TITLE
Update documentation with help for JPEG image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ from PIL import Image
 input_path = 'input.png'
 output_path = 'out.png'
 
+# Uncomment the following line if working with trucated image formats (ex. JPEG / JPG)
+# ImageFile.LOAD_TRUNCATED_IMAGES = True
+
 f = np.fromfile(input_path)
 result = remove(f)
 img = Image.open(io.BytesIO(result)).convert("RGBA")


### PR DESCRIPTION
Some people (myself included) use this library with JPEG images but Pillow recognizes the format as "truncated". By including the optional line in the README, it will help those trying to use the example with JPEGs spend less time scratching their head as to why it won't work. Example of the need can be found in #151 .