### PR TITLE
gdown version upgraded from 4.2.0 to 4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asyncer==0.0.1
 click==8.0.3
 fastapi==0.72.0
 filetype==1.0.9
-gdown==4.2.0
+gdown==4.3.1
 numpy==1.21.5
 onnxruntime==1.10.0
 pillow==9.0.0


### PR DESCRIPTION
The 4.2.0 version of package gdown was not able to download the u2net model. Problem resolved after upgrading version to 4.3.1.

Error Message: Cannot retrieve the public link of the file. You may need to change the permission to 'Anyone with the link', or have had many accesses.