### PR TITLE
a fix for number of threads in cluster infrastructure

### DIFF
--- a/rembg/detect.py
+++ b/rembg/detect.py
@@ -37,9 +37,12 @@ def ort_session(model_name: str) -> ort.InferenceSession:
             with redirect_stdout(sys.stderr):
                 gdown.download(url, str(path), use_cookies=False)
                 
-    sess_opts = ort.SessionOptions()
-    sess_opts.inter_op_num_threads = int(os.environ["OMP_NUM_THREADS"])  
-    sess_opts.intra_op_num_threads = int(os.environ["OMP_NUM_THREADS"]) 
+    if "OMP_NUM_THREADS" in os.environ:
+        sess_opts = ort.SessionOptions()
+        sess_opts.inter_op_num_threads = int(os.environ["OMP_NUM_THREADS"])  
+        sess_opts.intra_op_num_threads = int(os.environ["OMP_NUM_THREADS"])  
+    else:
+        sess_opts=None
     
     return ort.InferenceSession(str(path), providers=ort.get_available_providers(), sess_options=sess_opts)
 

--- a/rembg/detect.py
+++ b/rembg/detect.py
@@ -36,8 +36,12 @@ def ort_session(model_name: str) -> ort.InferenceSession:
         if hashing.hexdigest() != md5:
             with redirect_stdout(sys.stderr):
                 gdown.download(url, str(path), use_cookies=False)
-
-    return ort.InferenceSession(str(path), providers=ort.get_available_providers())
+                
+    sess_opts = ort.SessionOptions()
+    sess_opts.inter_op_num_threads = int(os.environ["OMP_NUM_THREADS"])  
+    sess_opts.intra_op_num_threads = int(os.environ["OMP_NUM_THREADS"]) 
+    
+    return ort.InferenceSession(str(path), providers=ort.get_available_providers(), sess_options=sess_opts)
 
 
 def norm_pred(d: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
This patch provides a fix to the following error message (cluster infrastructure): 
RuntimeError: /onnxruntime_src/onnxruntime/core/platform/posix/env.cc:183 onnxruntime::{anonymous}::PosixThread::PosixThr
ead(const char*, int, unsigned int (*)(int, Eigen::ThreadPoolInterface*), Eigen::ThreadPoolInterface*, const onnxruntime:
:ThreadOptions&) pthread_setaffinity_np failed, error code: 0 error msg:    