### PR TITLE
opencv-python => opencv-python-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ filetype==1.0.9
 gdown==4.5.1
 numpy==1.22.3
 onnxruntime==1.10.0
-opencv-python==4.6.0.66
+opencv-python-headless==4.6.0.66
 pillow==9.0.1
 pymatting==1.1.7
 python-multipart==0.0.5


### PR DESCRIPTION
Based on this https://github.com/opencv/opencv-python/issues/370#issuecomment-671202529 and a test executed with a non-GPU `python:3.9` Docker image