### PR TITLE
fix: Expected RGB image of shape (?, ?, 3), but image.shape is (?, ?, 4)

### DIFF
--- a/rembg/bg.py
+++ b/rembg/bg.py
@@ -37,6 +37,10 @@ def alpha_matting_cutout(
     background_threshold: int,
     erode_structure_size: int,
 ) -> PILImage:
+
+    if img.mode == "RGBA" or img.mode == "CMYK":
+        img = img.convert("RGB")
+
     img = np.asarray(img)
     mask = np.asarray(mask)
 


### PR DESCRIPTION

When the input image format is RGBA or CMYK, an exception occurs and the program exits.