### PR TITLE
Update the onnxruntime dependency version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fastapi==0.72.0
 filetype==1.0.9
 gdown==4.5.1
 numpy==1.22.3
-onnxruntime==1.10.0
+onnxruntime==1.12.0
 opencv-python-headless==4.6.0.66
 pillow==9.0.1
 pymatting==1.1.7


### PR DESCRIPTION
Let's update the onnxruntime version because the current one is not supported by m1 chips.

I've tested the build -- everything is fine as well as a happy path for 1 image. 

Should I try to run something else?