### PR TITLE
[FTR] feature/thread-limiter | Add anyio thread limiter

### DIFF
--- a/rembg/cli.py
+++ b/rembg/cli.py
@@ -257,7 +257,15 @@ def p(
     show_default=True,
     help="log level",
 )
-def s(port: int, log_level: str) -> None:
+@click.option(
+    "-t",
+    "--threads",
+    default=None,
+    type=int,
+    show_default=True,
+    help="number of worker threads",
+)
+def s(port: int, log_level: str, threads: int) -> None:
     sessions: dict[str, BaseSession] = {}
     tags_metadata = [
         {
@@ -383,6 +391,13 @@ def s(port: int, log_level: str) -> None:
             ),
             media_type="image/png",
         )
+
+    @app.on_event("startup")
+    def startup():
+        if threads is not None:
+            from anyio.lowlevel import RunVar
+            from anyio import CapacityLimiter
+            RunVar("_default_thread_limiter").set(CapacityLimiter(threads))
 
     @app.get(
         path="/",


### PR DESCRIPTION
This PR addresses the issue explained in #289 by limiting the number of threads in the managed thread pool by [`anyio`](https://anyio.readthedocs.io/en/stable/).

Relate to the discussion in [#tiangolo/fastapi/4221](https://github.com/tiangolo/fastapi/issues/4221#issuecomment-982260467) and an additional click option is added to specify the number of threads. This PR should serve as an extension to the current implementation and if no thread limit is specified the server should work as previously and thus be able to reproduce #289. 

However, if a thread limit is specified the response time will increase proportionally to the number of simultaneous requests, thus avoiding spawning threads until memory is filled.