### PR TITLE
Follow the XDG standard for storing u2net models

### DIFF
--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -37,7 +37,7 @@ def new_session(model_name: str) -> BaseSession:
             "Choose between u2net, u2netp, u2net_human_seg or u2net_cloth_seg"
         )
 
-    home = os.getenv("U2NET_HOME", os.path.join("~", ".u2net"))
+    home = os.getenv("U2NET_HOME", os.path.join(os.getenv("XDG_DATA_HOME", "~"), ".u2net"))
     path = Path(home).expanduser() / f"{model_name}.onnx"
     path.parents[0].mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
It is a bad practice in GNU/Linux to keep some dot files in the home directory.

There is an [XDG standard](https://specifications.freedesktop.org/basedir-spec/latest/ar01s02.html) that says that the directory to store user data files is defined by `$XDG_DATA_HOME` variable.

After this refinement, the order for selecting the models directory is as follows:
1. `$XDG_DATA_HOME/.u2net` (almost always `~/.local/share/.u2net`)
2. `~/.u2net` (if `$XDG_DATA_HOME` is not set)