### PR TITLE
Update resampling method to allow use of current Pillow version

### DIFF
--- a/rembg/session_base.py
+++ b/rembg/session_base.py
@@ -18,7 +18,7 @@ class BaseSession:
         std: Tuple[float, float, float],
         size: Tuple[int, int],
     ) -> Dict[str, np.ndarray]:
-        im = img.convert("RGB").resize(size, Image.Resampling.LANCZOS)
+        im = img.convert("RGB").resize(size, Image.LANCZOS)
 
         im_ary = np.array(im)
         im_ary = im_ary / np.max(im_ary)

--- a/rembg/session_simple.py
+++ b/rembg/session_simple.py
@@ -25,6 +25,6 @@ class SimpleSession(BaseSession):
         pred = np.squeeze(pred)
 
         mask = Image.fromarray((pred * 255).astype("uint8"), mode="L")
-        mask = mask.resize(img.size, Image.Resampling.LANCZOS)
+        mask = mask.resize(img.size, Image.LANCZOS)
 
         return [mask]


### PR DESCRIPTION
Since Pillow removed Resampling, these two function calls need to be updated.