### PR TITLE
New "rs" command:

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ Remove the background from an uploaded image
 curl -s -F file=@/path/to/input.jpg "http://localhost:5000"  -o output.png
 ```
 
+
+### rembg `rs`
+
+Process a sequence of RGB24 images from stdin. This is intended to be used with another program, such as FFMPEG, that outputs RGB24 pixel data to stdout, which is piped into the stdin of this program, although nothing prevents you from manually typing in images at stdin :)
+
+```
+rembg rs image_width image_height output_specifier
+```
+image_width : width of input image(s)
+image_height : height of input image(s)
+output_specifier: printf-style specifier for output filenames, for example if `abc%03u.png`, then output files will be named `abc000.png`, `abc001.png`, `abc002.png`, etc. Output files will be saved in PNG format regardless of the extension specified.
+
+Example usage with FFMPEG:
+
+```
+ffmpeg -i input.mp4 -ss 10 -an -f rawvideo -pix_fmt rgb24 pipe:1 | python rembg.py v 1280 720 out%03u.png
+```
+
+The width and height values must match the dimension of output images from FFMPEG. Note for FFMPEG, the "`-an -f rawvideo -pix_fmt rgb24 pipe:1`" part is required for the whole thing to work.
+
+
+
 ## Usage as a library
 
 Input and output as bytes

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ pip install rembg[gpu]
 
 After the installation step you can use rembg just typing `rembg` in your terminal window.
 
-The `rembg` command has 3 subcommands, one for each input type:
+The `rembg` command has 4 subcommands, one for each input type:
 - `i` for files
 - `p` for folders
 - `s` for http server
+- `rs` for piped binary RGB24 pixel data on stdin
 
 You can get help about the main command using:
 
@@ -188,9 +189,12 @@ Process a sequence of RGB24 images from stdin. This is intended to be used with 
 ```
 rembg rs image_width image_height output_specifier
 ```
-image_width : width of input image(s)
-image_height : height of input image(s)
-output_specifier: printf-style specifier for output filenames, for example if `abc%03u.png`, then output files will be named `abc000.png`, `abc001.png`, `abc002.png`, etc. Output files will be saved in PNG format regardless of the extension specified.
+
+Arguments:
+
+- image_width : width of input image(s)
+- image_height : height of input image(s)
+- output_specifier: printf-style specifier for output filenames, for example if `abc%03u.png`, then output files will be named `abc000.png`, `abc001.png`, `abc002.png`, etc. Output files will be saved in PNG format regardless of the extension specified.
 
 Example usage with FFMPEG:
 

--- a/rembg/bg.py
+++ b/rembg/bg.py
@@ -140,6 +140,7 @@ def remove(
         session = new_session("u2net")
 
     masks = session.predict(img)
+    #masks=[] #just to test, in this case, we'll end up with an image filled with background color
     cutouts = []
 
     for mask in masks:
@@ -166,9 +167,10 @@ def remove(
 
         cutouts.append(cutout)
 
-    cutout = img
     if len(cutouts) > 0:
         cutout = get_concat_v_multi(cutouts)
+    else: #this should not happen, but if it did, treat the entire image as background
+        cutout=Image.new("RGBA", img.size, (0,0,0,0))
 
     if bgcolor is not None and not only_mask:
         cutout = apply_background_color(cutout, bgcolor)

--- a/rembg/cli.py
+++ b/rembg/cli.py
@@ -21,7 +21,6 @@ from .bg import remove
 from .session_base import BaseSession
 from .session_factory import new_session
 
-
 @click.group()
 @click.version_option(version=_version.get_versions()["version"])
 def main() -> None:
@@ -614,7 +613,7 @@ def rs(model: str, threads:int, image_width:int, image_height:int, output_specif
 
     #print(f"rs: model={model} threads={threads} xs={image_width} ys={image_height} out_file_spec={output_specifier}\n")
     output_dir=os.path.dirname(os.path.abspath(output_specifier))
-    if not os.path.isdir(output_dir): os.makedirs(output_dir)
+    if not os.path.isdir(output_dir): os.makedirs(output_dir, exist_ok=True)
 
     lck=threading.Lock() #threads must acquire lock before reading input
     img_index:int=0 #volatile, can be updated by any thread


### PR DESCRIPTION
Usage: rembg.py rs [OPTIONS] IMAGE_WIDTH IMAGE_HEIGHT OUTPUT_SPECIFIER

  Process a sequence of RGB24 images from stdin. This is intended to be used
  with another program, such as FFMPEG, that outputs RGB24 pixel data to
  stdout, which is piped into the stdin of this program, although nothing
  prevents you from manually typing in images at stdin :)

  image_width, image_height : dimension of image(s)

  output_specifier: printf-style specifier for output filenames, for example
  if abc%03u.png, then output files will be named abc000.png, abc001.png,
  abc002.png, etc. Output files will be saved in PNG format regardless of the
  extension specified.

  Example usage with FFMPEG:

    ffmpeg -i input.mp4 -ss 10 -an -f rawvideo -pix_fmt rgb24 pipe:1 | python rembg.py v 1280 720 out%03u.png

  The width and height values must match the dimension of output images from
  FFMPEG. Note for FFMPEG, the "-an -f rawvideo -pix_fmt rgb24 pipe:1" part is
  required.