### PR TITLE
added fix for image orientation

### DIFF
--- a/rembg/bg.py
+++ b/rembg/bg.py
@@ -11,7 +11,7 @@ from cv2 import (
     getStructuringElement,
     morphologyEx,
 )
-from PIL import Image
+from PIL import Image, ImageOps
 from PIL.Image import Image as PILImage
 from pymatting.alpha.estimate_alpha_cf import estimate_alpha_cf
 from pymatting.foreground.estimate_foreground_ml import estimate_foreground_ml
@@ -113,6 +113,10 @@ def apply_background_color(img: PILImage, color: Tuple[int, int, int, int]) -> P
     return colored_image
 
 
+def fix_image_orientation(img: PILImage) -> PILImage:
+    return ImageOps.exif_transpose(img)
+
+
 def remove(
     data: Union[bytes, PILImage, np.ndarray],
     alpha_matting: bool = False,
@@ -137,6 +141,9 @@ def remove(
         img = Image.fromarray(data)
     else:
         raise ValueError("Input type {} is not supported.".format(type(data)))
+
+    # Fix image orientation
+    img = fix_image_orientation(img)
 
     if session is None:
         session = new_session("u2net", *args, **kwargs)


### PR DESCRIPTION
On some images it can happen that the image orientation is wrong. For example, I often noticed it with iPhone pictures. I added a small function which checks if an image has an EXIF Orientation tag, other than 1 and  return a new image that is transposed accordingly.

@danielgatis Hey, I know that you have a lot to do. This is now my 4th contribution to this repo. I wanted to ask if it is possible to get maintainer rights on this repo so I can help you with the Issues and Pull Requests?