### PR TITLE
Fix poetry install errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="remove, background, u2net",
-    python_requires=">=3.8, <3.12",
+    python_requires=">=3.8, <4.0",
     packages=find_packages(),
     install_requires=install_requires,
     entry_points=entry_points,


### PR DESCRIPTION
This change updates the setup.py so that it will install for higher versions of python in pyproject.toml with  ^3.10 or ^3.11 version.

Currently the work around is to use the ~ symbol.

Error example:

  - rembg requires Python >=3.8, <3.12, so it will not be satisfied for Python >=3.12,<4.0