### PR TITLE
Apply thread limit to intra_op_num_threads

### DIFF
--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -22,5 +22,6 @@ def new_session(
 
     if "OMP_NUM_THREADS" in os.environ:
         sess_opts.inter_op_num_threads = int(os.environ["OMP_NUM_THREADS"])
+        sess_opts.intra_op_num_threads = int(os.environ["OMP_NUM_THREADS"])
 
     return session_class(model_name, sess_opts, providers, *args, **kwargs)


### PR DESCRIPTION
On virtualized systems `pthread_setaffinity_np()` call can fail when setting the affinity mask of the thread on the guest system. You have to set a limit to the number of threads manually as suggested by error. 

There already is `OMP_NUM_THREADS` environment variable in the library, which allows you to set a limit for the number of ONNX Runtime `inter_op_num_threads`.  There also is a second thread limit `intra_op_num_threads`.

When running into this error, both thread limits have to be set otherwise ONNX Runtime keeps crashing. Relates to https://github.com/danielgatis/rembg/issues/448