### PR TITLE
Simplify Boolean Expressions Using `startswith` and `endswith` 

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1319,7 +1319,7 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
         files.append(ipy)
     try:
         my_path = __file__
-        if my_path.endswith(".pyc") or my_path.endswith(".pyo"):
+        if my_path.endswith((".pyc", ".pyo")):
             my_path = os.path.splitext(my_path)[0] + ".py"
         versioneer_file = os.path.relpath(my_path)
     except NameError:


### PR DESCRIPTION
Many developers are not necessarily aware that the `startswith` and `endswith` methods of `str` objects can accept a tuple of strings to match. This means that there is a lot of code that uses boolean expressions such as `x.startswith('foo') or x.startswith('bar')` instead of the simpler expression `x.startswith(('foo', 'bar'))`.

This codemod simplifies the boolean expressions where possible which leads to cleaner and more concise code.

The changes from this codemod look like this:

```diff
  x = 'foo'
- if x.startswith("foo") or x.startswith("bar"):
+ if x.startswith(("foo", "bar")):
     ...
```

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/combine-startswith-endswith](https://docs.pixee.ai/codemods/python/pixee_python_combine-startswith-endswith)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Cpixeeai%2Frembg%7Cdb238e35bfc922c3b340a99bc39ae4f11286b824)

<!--{"type":"DRIP","codemod":"pixee:python/combine-startswith-endswith"}-->