### PR TITLE
Always assume python bytes type IF not PILImage or np.ndarray

### DIFF
--- a/rembg/bg.py
+++ b/rembg/bg.py
@@ -240,14 +240,12 @@ def remove(
     if isinstance(data, PILImage):
         return_type = ReturnType.PILLOW
         img = data
-    elif isinstance(data, bytes):
-        return_type = ReturnType.BYTES
-        img = Image.open(io.BytesIO(data))
     elif isinstance(data, np.ndarray):
         return_type = ReturnType.NDARRAY
         img = Image.fromarray(data)
     else:
-        raise ValueError("Input type {} is not supported.".format(type(data)))
+        return_type = ReturnType.BYTES
+        img = Image.open(io.BytesIO(data))
 
     putalpha = kwargs.pop("putalpha", False)
 


### PR DESCRIPTION
When working with pythonnet in c#, we can't provide python bytes types.  Although this will fix the call from C#, not sure about other scenario.