### PR TITLE
Replace pooch retrieve calls with create followed by fetch to benefit from the retry_if_failed feature

### DIFF
--- a/rembg/sessions/birefnet_cod.py
+++ b/rembg/sessions/birefnet_cod.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-COD session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-COD model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-COD-epoch_125.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:f6d0d21ca89d287f17e7afe9f5fd3b45"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-cod"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-COD file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-COD-epoch_125.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-COD model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:f6d0d21ca89d287f17e7afe9f5fd3b45"

--- a/rembg/sessions/birefnet_cod.py
+++ b/rembg/sessions/birefnet_cod.py
@@ -37,13 +37,13 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-COD model file.
+        Returns the hash of the BiRefNet-COD model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:f6d0d21ca89d287f17e7afe9f5fd3b45"

--- a/rembg/sessions/birefnet_cod.py
+++ b/rembg/sessions/birefnet_cod.py
@@ -35,7 +35,7 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
         return "BiRefNet-COD-epoch_125.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-COD model file.
 

--- a/rembg/sessions/birefnet_cod.py
+++ b/rembg/sessions/birefnet_cod.py
@@ -19,7 +19,7 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-cod"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionCOD(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-COD-epoch_125.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_dis.py
+++ b/rembg/sessions/birefnet_dis.py
@@ -19,7 +19,7 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-dis"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-DIS-epoch_590.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_dis.py
+++ b/rembg/sessions/birefnet_dis.py
@@ -35,7 +35,7 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
         return "BiRefNet-DIS-epoch_590.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-DIS model file.
 

--- a/rembg/sessions/birefnet_dis.py
+++ b/rembg/sessions/birefnet_dis.py
@@ -37,13 +37,13 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-DIS model file.
+        Returns the hash of the BiRefNet-DIS model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:2d4d44102b446f33a4ebb2e56c051f2b"

--- a/rembg/sessions/birefnet_dis.py
+++ b/rembg/sessions/birefnet_dis.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-DIS session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-DIS model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-DIS-epoch_590.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:2d4d44102b446f33a4ebb2e56c051f2b"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionDIS(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-dis"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-DIS file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-DIS-epoch_590.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-DIS model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:2d4d44102b446f33a4ebb2e56c051f2b"

--- a/rembg/sessions/birefnet_general.py
+++ b/rembg/sessions/birefnet_general.py
@@ -76,15 +76,10 @@ class BiRefNetSessionGeneral(BaseSession):
                     else cls.model_hash(*args, **kwargs)
                 )
             },
-            urls={
-                fname: url
-            },
-            retry_if_failed=2
+            urls={fname: url},
+            retry_if_failed=2,
         )
-        pooch_instance.fetch(
-            fname,
-            progressbar=True
-        )
+        pooch_instance.fetch(fname, progressbar=True)
 
         return os.path.join(path, fname)
 
@@ -101,7 +96,7 @@ class BiRefNetSessionGeneral(BaseSession):
             str: The name of the session.
         """
         return "birefnet-general"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -115,7 +110,7 @@ class BiRefNetSessionGeneral(BaseSession):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-general-epoch_244.onnx"
-    
+
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_general_lite.py
+++ b/rembg/sessions/birefnet_general_lite.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-General-Lite session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-General-Lite model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-general-bb_swin_v1_tiny-epoch_232.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:4fab47adc4ff364be1713e97b7e66334"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-general-lite"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-General-Lite file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-general-bb_swin_v1_tiny-epoch_232.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-General-Lite model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:4fab47adc4ff364be1713e97b7e66334"

--- a/rembg/sessions/birefnet_general_lite.py
+++ b/rembg/sessions/birefnet_general_lite.py
@@ -35,7 +35,7 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
         return "BiRefNet-general-bb_swin_v1_tiny-epoch_232.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-General-Lite model file.
 

--- a/rembg/sessions/birefnet_general_lite.py
+++ b/rembg/sessions/birefnet_general_lite.py
@@ -37,13 +37,13 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-General-Lite model file.
+        Returns the hash of the BiRefNet-General-Lite model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:4fab47adc4ff364be1713e97b7e66334"

--- a/rembg/sessions/birefnet_general_lite.py
+++ b/rembg/sessions/birefnet_general_lite.py
@@ -19,7 +19,7 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-general-lite"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionGeneralLite(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-general-bb_swin_v1_tiny-epoch_232.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_hrsod.py
+++ b/rembg/sessions/birefnet_hrsod.py
@@ -35,7 +35,7 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
         return "BiRefNet-HRSOD_DHU-epoch_115.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-HRSOD model file.
 

--- a/rembg/sessions/birefnet_hrsod.py
+++ b/rembg/sessions/birefnet_hrsod.py
@@ -19,7 +19,7 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-hrsod"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-HRSOD_DHU-epoch_115.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_hrsod.py
+++ b/rembg/sessions/birefnet_hrsod.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-HRSOD session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-HRSOD model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-HRSOD_DHU-epoch_115.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:c017ade5de8a50ff0fd74d790d268dda"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-hrsod"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-HRSOD file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-HRSOD_DHU-epoch_115.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-HRSOD model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:c017ade5de8a50ff0fd74d790d268dda"

--- a/rembg/sessions/birefnet_hrsod.py
+++ b/rembg/sessions/birefnet_hrsod.py
@@ -37,13 +37,13 @@ class BiRefNetSessionHRSOD(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-HRSOD model file.
+        Returns the hash of the BiRefNet-HRSOD model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:c017ade5de8a50ff0fd74d790d268dda"

--- a/rembg/sessions/birefnet_massive.py
+++ b/rembg/sessions/birefnet_massive.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-Massive session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-Massive model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-massive-TR_DIS5K_TR_TEs-epoch_420.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:33e726a2136a3d59eb0fdf613e31e3e9"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-massive"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-Massive file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-massive-TR_DIS5K_TR_TEs-epoch_420.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-Massive model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:33e726a2136a3d59eb0fdf613e31e3e9"

--- a/rembg/sessions/birefnet_massive.py
+++ b/rembg/sessions/birefnet_massive.py
@@ -37,13 +37,13 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-Massive model file.
+        Returns the hash of the BiRefNet-Massive model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:33e726a2136a3d59eb0fdf613e31e3e9"

--- a/rembg/sessions/birefnet_massive.py
+++ b/rembg/sessions/birefnet_massive.py
@@ -35,7 +35,7 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
         return "BiRefNet-massive-TR_DIS5K_TR_TEs-epoch_420.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-Massive model file.
 

--- a/rembg/sessions/birefnet_massive.py
+++ b/rembg/sessions/birefnet_massive.py
@@ -19,7 +19,7 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-massive"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionMassive(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-massive-TR_DIS5K_TR_TEs-epoch_420.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_portrait.py
+++ b/rembg/sessions/birefnet_portrait.py
@@ -35,7 +35,7 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
         return "BiRefNet-portrait-epoch_150.onnx"
 
     @classmethod
-    def model_md5(cls, *args, **kwargs):
+    def model_hash(cls, *args, **kwargs):
         """
         Returns the md5 of the BiRefNet-Portrait model file.
 

--- a/rembg/sessions/birefnet_portrait.py
+++ b/rembg/sessions/birefnet_portrait.py
@@ -19,7 +19,7 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-portrait"
-    
+
     @classmethod
     def url_fname(cls, *args, **kwargs):
         """
@@ -33,7 +33,7 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
             str: The name of the model file in the model url.
         """
         return "BiRefNet-portrait-epoch_150.onnx"
-    
+
     @classmethod
     def model_md5(cls, *args, **kwargs):
         """

--- a/rembg/sessions/birefnet_portrait.py
+++ b/rembg/sessions/birefnet_portrait.py
@@ -1,7 +1,3 @@
-import os
-
-import pooch
-
 from . import BiRefNetSessionGeneral
 
 
@@ -9,33 +5,6 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
     """
     This class represents a BiRefNet-Portrait session, which is a subclass of BiRefNetSessionGeneral.
     """
-
-    @classmethod
-    def download_models(cls, *args, **kwargs):
-        """
-        Downloads the BiRefNet-Portrait model file from a specific URL and saves it.
-
-        Parameters:
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            str: The path to the downloaded model file.
-        """
-        fname = f"{cls.name(*args, **kwargs)}.onnx"
-        pooch.retrieve(
-            "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-portrait-epoch_150.onnx",
-            (
-                None
-                if cls.checksum_disabled(*args, **kwargs)
-                else "md5:c3a64a6abf20250d090cd055f12a3b67"
-            ),
-            fname=fname,
-            path=cls.u2net_home(*args, **kwargs),
-            progressbar=True,
-        )
-
-        return os.path.join(cls.u2net_home(*args, **kwargs), fname)
 
     @classmethod
     def name(cls, *args, **kwargs):
@@ -50,3 +19,31 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
             str: The name of the session.
         """
         return "birefnet-portrait"
+    
+    @classmethod
+    def url_fname(cls, *args, **kwargs):
+        """
+        Returns the name of the BiRefNet-Portrait file in the model url.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The name of the model file in the model url.
+        """
+        return "BiRefNet-portrait-epoch_150.onnx"
+    
+    @classmethod
+    def model_md5(cls, *args, **kwargs):
+        """
+        Returns the md5 of the BiRefNet-Portrait model file.
+
+        Parameters:
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The md5 of the model file.
+        """
+        return "md5:c3a64a6abf20250d090cd055f12a3b67"

--- a/rembg/sessions/birefnet_portrait.py
+++ b/rembg/sessions/birefnet_portrait.py
@@ -37,13 +37,13 @@ class BiRefNetSessionPortrait(BiRefNetSessionGeneral):
     @classmethod
     def model_hash(cls, *args, **kwargs):
         """
-        Returns the md5 of the BiRefNet-Portrait model file.
+        Returns the hash of the BiRefNet-Portrait model file.
 
         Parameters:
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            str: The md5 of the model file.
+            str: The hash of the model file.
         """
         return "md5:c3a64a6abf20250d090cd055f12a3b67"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require = {
         "gradio",
         "python-multipart",
         "uvicorn",
-        "watchdog",
+        "watchdog < 5.0.0",
     ],
 }
 


### PR DESCRIPTION
This is a replacement of `pooch.retrieve` with `pooch.create` and `pooch.fetch` to allow the use of the `retry_if_failed` parameter. 

For the moment, I only did the modification for the BiRefNet sessions as they were the ones that were crashing but this modification can also be applied to other sessions as well (except `sam` and `unet_custom` that are too specific). Let me know if you'd like me to adapt other sessions as well.

Please, don't hesitate to tell me if it's not relevant anymore as you already fixed the test issue (but I guess it may be helpful for end users to have retries as well, just in case).