### PR TITLE
quote package name to fix installation on zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ CPU support:
 
 ```bash
 pip install rembg # for library
-pip install rembg[cli] # for library + cli
+pip install "rembg[cli]" # for library + cli
 ```
 
 GPU support:
@@ -94,8 +94,8 @@ Go to <https://onnxruntime.ai> and check the installation matrix.
 If yes, just run:
 
 ```bash
-pip install rembg[gpu] # for library
-pip install rembg[gpu,cli] # for library + cli
+pip install "rembg[GPU]" # for library
+pip install "rembg[gpu,cli]" # for library + cli
 ```
 
 ## Usage as a cli


### PR DESCRIPTION
Make sure installation instructions work with zsh on mac.

### Before fix
```bash
pip install rembg[cli]                                                                                                                                                                                                                                                                                
zsh: no matches found: rembg[cli]
```

### After fix
```bash
pip install "rembg[cli]"                                                                                                                                                                                                                                                                          
Requirement already satisfied: rembg[cli] in ./lib/python3.12/site-packages (2.0.59)
Requirement already satisfied: jsonschema in ./lib/python3.12/site-packages (from rembg[cli]) (4.23.0)
Requirement already satisfied: numpy in ./lib/python3.12/site-packages (from rembg[cli]) (2.0.2)
Requirement already satisfied: onnxruntime in ./lib/python3.12/site-packages (from rembg[cli]) (1.19.2)
Requirement already satisfied: opencv-python-headless in ./lib/python3.12/site-packages (from rembg[cli]) (4.10.0.84)
Requirement already satisfied: pillow in ./lib/python3.12/site-packages (from rembg[cli]) (10.4.0)
Requirement already satisfied: pooch in ./lib/python3.12/site-packages (from rembg[cli]) (1.8.2)
Requirement already satisfied: pymatting in ./lib/python3.12/site-packages (from rembg[cli]) (1.1.12)
Requirement already satisfied: scikit-image in ./lib/python3.12/site-packages (from rembg[cli]) (0.24.0)
Requirement already satisfied: scipy in ./lib/python3.12/site-packages (from rembg[cli]) (1.14.1)
Requirement already satisfied: tqdm in ./lib/python3.12/site-packages (from rembg[cli]) (4.66.5)
Collecting aiohttp (from rembg[cli])
  Downloading aiohttp-3.10.6-cp312-cp312-macosx_11_0_arm64.whl.metadata (7.6 kB)
...
```