### PR TITLE
Dependency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,20 @@ python: >3.7, <3.13
 
 ## Installation
 
-CPU support:
+If you have `onnxruntime` already installed, just install `rembg`:
 
 ```bash
 pip install rembg # for library
 pip install "rembg[cli]" # for library + cli
+```
+
+Otherwise, install `rembg` with explicit CPU/GPU support.
+
+CPU support:
+
+```bash
+pip install rembg[cpu] # for library
+pip install "rembg[cpu,cli]" # for library + cli
 ```
 
 GPU support:
@@ -94,7 +103,7 @@ Go to <https://onnxruntime.ai> and check the installation matrix.
 If yes, just run:
 
 ```bash
-pip install "rembg[GPU]" # for library
+pip install "rembg[gpu]" # for library
 pip install "rembg[gpu,cli]" # for library + cli
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 install_requires = [
     "jsonschema",
     "numpy",
-    "onnxruntime",
     "opencv-python-headless",
     "pillow",
     "pooch",
@@ -37,6 +36,7 @@ extras_require = {
         "twine",
         "wheel",
     ],
+    "cpu": ["onnxruntime"],
     "gpu": ["onnxruntime-gpu"],
     "cli": [
         "aiohttp",


### PR DESCRIPTION
Hello Daniel. First of all, thanks for this awesome package, the results look really great.

However, after installing `rembg`, I noticed that performance of my environment decreased rapidly. It was caused by having a hard dependency on `onnxruntime`. Even when installing the `rembg[gpu]` variant, it messed my `onnxruntime-gpu` installation.

I could not find a better solution than provide `rembg[cpu]`, which would install `onnxruntime` explicitly. What do you think?