### PR TITLE
chore: Disable analytics in Gradio interface

### DIFF
--- a/rembg/commands/s_command.py
+++ b/rembg/commands/s_command.py
@@ -306,6 +306,7 @@ def s_command(port: int, host: str, log_level: str, threads: int) -> None:
             ],
             gr.components.Image(type="filepath", label="Output"),
             concurrency_limit=3,
+            analytics_enabled=False,
         )
 
         app = gr.mount_gradio_app(app, interface, path="/")


### PR DESCRIPTION
This commit disables the analytics feature in the Gradio interface within the `s_command.py` file. Disabling analytics can help maintain user privacy and align with data protection policies or organizational guidelines. The change involves adding the `analytics_enabled=False` parameter to the `gr.Interface` constructor, ensuring that no usage data is collected from users interacting with the application.

Presently, the environment is the only way to disable it. Something like:

```bash
env GRADIO_ANALYTICS_ENABLED=False rembg i ~/Pictures/input.png ~/Pictures/output.png
```