### PR TITLE
onnxruntime is required by all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "scikit-image",
     "scipy",
     "tqdm",
+    "onnxruntime",
 ]
 
 extras_require = {
@@ -36,7 +37,7 @@ extras_require = {
         "twine",
         "wheel",
     ],
-    "cpu": ["onnxruntime"],
+    "cpu": [],
     "gpu": ["onnxruntime-gpu"],
     "cli": [
         "aiohttp",


### PR DESCRIPTION
I just had the cli crash on a fresh pip install because onnxruntime was missing. Pretty sure onnxruntime is a global requirement.
I had to run
```
pip install rembg[cli] onnxruntime
```
to have the cli *not* crash.