### PR TITLE
rembg b - return a stream of RGB24 instead of a mess of consecutive pngs

### DIFF
--- a/rembg/commands/b_command.py
+++ b/rembg/commands/b_command.py
@@ -135,9 +135,7 @@ def b_command(
             os.makedirs(output_dir, exist_ok=True)
 
     def img_to_byte_array(img: PILImage) -> bytes:
-        buff = io.BytesIO()
-        img.save(buff, format="PNG")
-        return buff.getvalue()
+        return img.convert('RGB').tobytes("raw", "RGB")
 
     async def connect_stdin_stdout():
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
This PR makes it so that the output of __rembg_ b_ is the same format as the input allowing for piping both the output and the input.

Without this PR the output is a stream of png's without delimiters that would indicate where one png ends and the next begins, a format that results in a stream where most tools can only access the first png in the stream.

With this PR you can pipe from ffmpeg in to rembg and then back in to ffmpeg like this:
```bash
COLOR_VIDEO=$1

VIDEO_WIDTH=1440
VIDEO_HEIGHT=1080
VIDEO_FPS=25

ffmpeg -i COLOR_VIDEO -ss 1 -an -f rawvideo -pix_fmt rgb24 pipe:1 | rembg b ${VIDEO_WIDTH} ${VIDEO_HEIGHT} | ffmpeg -y -f rawvideo -pix_fmt rgb24 -s ${VIDEO_WIDTH}x${VIDEO_HEIGHT} -r ${VIDEO_FPS} -i pipe:0 -preset fast mask.mp4

```