### PR TITLE
Fix "Always using CPU, ingore GPU" issue, caused by onnxruntime's strange behavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ pip install "rembg[cli]" # for library + cli
 
 Otherwise, install `rembg` with explicit CPU/GPU support.
 
-CPU support:
+### CPU support:
 
 ```bash
 pip install rembg[cpu] # for library
 pip install "rembg[cpu,cli]" # for library + cli
 ```
 
-GPU support:
+### GPU support:
 
 First of all, you need to check if your system supports the `onnxruntime-gpu`.
 
@@ -123,6 +123,8 @@ If yes, just run:
 pip install "rembg[gpu]" # for library
 pip install "rembg[gpu,cli]" # for library + cli
 ```
+
+Nvidia GPU may require onnxruntime-gpu, cuda, and cudnn-devel. [#668](https://github.com/danielgatis/rembg/issues/668#issuecomment-2689830314) . If rembg[gpu] couldn't work probably and your can't install cuda or cudnn-devel, use rembg[cpu] and onnxruntime instead.
 
 ## Usage as a cli
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ Try this:
 docker run -v path/to/input:/rembg danielgatis/rembg i input.png path/to/output/output.png
 ```
 
+Notice: Right now docker version only support CPU Acceleration.
+
 ## Models
 
 All models are downloaded and saved in the user home folder in the `.u2net` directory.

--- a/rembg/sessions/base.py
+++ b/rembg/sessions/base.py
@@ -13,9 +13,17 @@ class BaseSession:
     def __init__(self, model_name: str, sess_opts: ort.SessionOptions, *args, **kwargs):
         """Initialize an instance of the BaseSession class."""
         self.model_name = model_name
+
+        device_type = ort.get_device()
+        if device_type == 'GPU' and 'CUDAExecutionProvider' in ort.get_available_providers():
+            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        else:
+            providers = ['CPUExecutionProvider']
+
         self.inner_session = ort.InferenceSession(
             str(self.__class__.download_models(*args, **kwargs)),
             sess_options=sess_opts,
+            providers=providers,
         )
 
     def normalize(


### PR DESCRIPTION
Main discussion: <https://github.com/danielgatis/rembg/issues/668#issuecomment-2670558679>

Right now the onnxruntime-gpu version is confirmed as 1.20.1 by `print(onnxruntime.__version__)`. It has a strange behaver: If you don't provide **Execution Provider**, it use **CPUExecutionProvider** by default.
To use GPU Acceleration, **CUDAExecutionProvider** must be sent as an arg.

I think this onnxruntime strange behavor is relate to many issues, like #682 #664 #707 #439 #696 .

Test on Linux with onnxruntime and onnxruntime-gpu.
I'm not very sure how would works on other platforms.

