### PR TITLE
Citing repository

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+title: rembg
+message: Rembg is a tool to remove images background
+type: software
+authors:
+  - given-names: Daniel
+    family-names: Gatis
+    email: danielgatis@gmail.com
+identifiers:
+  - type: url
+    value: 'https://github.com/danielgatis'
+repository-code: 'https://github.com/danielgatis/rembg'
+url: 'https://github.com/danielgatis/rembg'
+abstract: Rembg is a tool to remove images background.
+license: MIT
+commit: 9079508935ae55d6eefa0fd75f870599640e8593
+version: 2.0.63
+date-released: '2025-02-21'
+


### PR DESCRIPTION
Closes #726

This PR adds a file `CITATION.cff` that causes _Cite this repository_ to show up in the sidebar. The file requires minimal maintenance and only these 3 lines have to be updated every release:
```
commit:
version:
date-released:
```

![citation](https://github.com/user-attachments/assets/0deba2d9-4561-46d8-92dc-ed3a371d062b)
