### PR TITLE
fix IS-Net normalization values

### DIFF
--- a/rembg/sessions/dis_general_use.py
+++ b/rembg/sessions/dis_general_use.py
@@ -24,7 +24,7 @@ class DisSession(BaseSession):
         """
         ort_outs = self.inner_session.run(
             None,
-            self.normalize(img, (0.485, 0.456, 0.406), (1.0, 1.0, 1.0), (1024, 1024)),
+            self.normalize(img, (0.5, 0.5, 0.5), (1.0, 1.0, 1.0), (1024, 1024)),
         )
 
         pred = ort_outs[0][:, 0, :, :]


### PR DESCRIPTION
The current implementation uses ImageNet normalization values, but the IS-Net models were trained with different normalization parameters, check the [link](https://github.com/xuebinqin/DIS/blob/b6764e20381f6f42a70f83fa3324181529ed1403/IS-Net/train_valid_inference_main.py#L542)
