### PR TITLE
Stop publishing arm64 image

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish_docker:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,10 +43,10 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The arm64 docker image is much slower to build and download models. With the addition of the extra models, it's now too big to build and push in Github actions (times out after several hours).

This change removes the arm64 image in favor of just the amd64 image, which only takes about 9 minutes to build and push.

More discussion at: https://github.com/danielgatis/rembg/discussions/735