### PR TITLE
Fix (and document) support for ROCM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ pip install rembg[cpu] # for library
 pip install "rembg[cpu,cli]" # for library + cli
 ```
 
-### GPU support:
+### GPU support (NVidia/Cuda):
 
 First of all, you need to check if your system supports the `onnxruntime-gpu`.
 
@@ -125,6 +125,19 @@ pip install "rembg[gpu,cli]" # for library + cli
 ```
 
 Nvidia GPU may require onnxruntime-gpu, cuda, and cudnn-devel. [#668](https://github.com/danielgatis/rembg/issues/668#issuecomment-2689830314) . If rembg[gpu] doesn't work and you can't install cuda or cudnn-devel, use rembg[cpu] and onnxruntime instead.
+
+### GPU support (AMD/ROCM):
+
+ROCM support requires the `onnxruntime-rocm` package. Install it following
+[AMD's documentation](https://rocm.docs.amd.com/projects/radeon/en/latest/docs/install/native_linux/install-onnx.html).
+
+If `onnxruntime-rocm` is installed and working, install the `rembg[rocm]`
+version of rembg:
+
+```bash
+pip install "rembg[rocm]" # for library
+pip install "rembg[rocm,cli]" # for library + cli
+```
 
 ## Usage as a cli
 

--- a/rembg/sessions/base.py
+++ b/rembg/sessions/base.py
@@ -20,6 +20,11 @@ class BaseSession:
             and "CUDAExecutionProvider" in ort.get_available_providers()
         ):
             providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        elif (
+            device_type[0:3] == "GPU"
+            and "ROCMExecutionProvider" in ort.get_available_providers()
+        ):
+            providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
         else:
             providers = ["CPUExecutionProvider"]
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extras_require = {
     ],
     "cpu": ["onnxruntime"],
     "gpu": ["onnxruntime-gpu"],
+    "rocm": ["onnxruntime-rocm"],
     "cli": [
         "aiohttp",
         "asyncer",


### PR DESCRIPTION
Commit aa6fb76 broke support for ROCM (AMD GPUs), and presumably all other GPU backends, by explicitly checking for Cuda. I assume that the rationale behind this was to make sure that Cuda is only used if a GPU is actually present, but the whitelisting style broke everything else.

This change re-adds support for ROCM, with the same whitelist style. Since ROCM is supported by a different package, I've also documented how to install it, and added a `rembg[rocm]` package to mark that dependency.

Note that the reason for checking `device[0:3]` is that the ROCM backends report "GPU-MIGRAPHX" or "GPU-ROCM" or who knows what else, but they all start with "GPU".