### PR TITLE
Add configurable execution providers support for testing environments

### DIFF
--- a/rembg/sessions/base.py
+++ b/rembg/sessions/base.py
@@ -13,20 +13,23 @@ class BaseSession:
     def __init__(self, model_name: str, sess_opts: ort.SessionOptions, *args, **kwargs):
         """Initialize an instance of the BaseSession class."""
         self.model_name = model_name
-
-        device_type = ort.get_device()
-        if (
-            device_type == "GPU"
-            and "CUDAExecutionProvider" in ort.get_available_providers()
-        ):
-            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-        elif (
-            device_type[0:3] == "GPU"
-            and "ROCMExecutionProvider" in ort.get_available_providers()
-        ):
-            providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
+        
+        if "providers" in kwargs and isinstance(kwargs["providers"], list):
+            providers = kwargs.pop("providers")
         else:
-            providers = ["CPUExecutionProvider"]
+            device_type = ort.get_device()
+            if (
+                device_type == "GPU"
+                and "CUDAExecutionProvider" in ort.get_available_providers()
+            ):
+                providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            elif (
+                device_type[0:3] == "GPU"
+                and "ROCMExecutionProvider" in ort.get_available_providers()
+            ):
+                providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
+            else:
+                providers = ["CPUExecutionProvider"]
 
         self.inner_session = ort.InferenceSession(
             str(self.__class__.download_models(*args, **kwargs)),


### PR DESCRIPTION
**Problem:**
When building Docker images with `onnxruntime-gpu` for GPU devices but testing on CI/CD environments without GPUs (like GitHub Actions), `onnxruntime-gpu` automatically selects `CudaExecutionProvider` even when CUDA isn't available, causing runtime failures.

**Solution:**
Allow manual specification of execution providers via a providers parameter in the constructor. This enables:

- Testing GPU-built images on CPU-only CI environments
-  Explicit control over execution provider selection
- Backward compatibility with existing automatic provider detection

**Changes:**

- Added optional providers parameter to __init__() method
- Maintains existing auto-detection logic as fallback
- Supports both CUDA and ROCm GPU providers

**Usage:**
For CI/testing environments
```py
from rembg import new_session

providers = ["CPUExecutionProvider"]
session = new_session(providers=providers)

# Existing behavior unchanged
session = new_session()  # Auto-detects providers
```

This change enables seamless testing of GPU-optimized builds in CPU-only environments without requiring separate CPU-specific builds.