### PR TITLE
Add manual page for the command line interface

### DIFF
--- a/man/rembg.1
+++ b/man/rembg.1
@@ -1,0 +1,20 @@
+.TH REMBG 1 "Januar 2026" "2.0.72" "User Commands"
+.SH NAME
+rembg \- tool to remove background from images
+.SH SYNOPSIS
+.B rembg
+[OPTIONS] COMMAND [ARGS]...
+.SH DESCRIPTION
+.B rembg
+is a tool to remove images background.
+.PP
+It works as a command line interface and a library.
+.SH OPTIONS
+.TP
+.BR \-\-version
+Show the version and exit.
+.TP
+.BR \-\-help
+Show this message and exit.
+.SH SEE ALSO
+Full documentation at: <https://github.com/danielgatis/rembg>


### PR DESCRIPTION
Hi! 

I am currently packaging rembg for Debian. 
As part of the Debian Policy, we provide manual pages for executable binaries. 
I have written a basic manpage for the rembg CLI and would like to contribute it to your project so other distributions can benefit from it as well.

You can find the file attached/included in this PR.

If you have any questions, feel free to ask.

Regards,
Arian Ott