### PR TITLE
Support passing ort sess_opts to session factory

### DIFF
--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -8,17 +8,18 @@ from .sessions.base import BaseSession
 from .sessions.u2net import U2netSession
 
 
-def new_session(model_name: str = "u2net", *args, **kwargs) -> BaseSession:
+def new_session(model_name: str = "u2net", *args, sess_opts: Optional[ort.SessionOptions] = None, **kwargs) -> BaseSession:
     """
     Create a new session object based on the specified model name.
 
     This function searches for the session class based on the model name in the 'sessions_class' list.
     It then creates an instance of the session class with the provided arguments.
-    The 'sess_opts' object is created using the 'ort.SessionOptions()' constructor.
-    If the 'OMP_NUM_THREADS' environment variable is set, the 'inter_op_num_threads' option of 'sess_opts' is set to its value.
+    If not provided, the 'sess_opts' object is created using the 'ort.SessionOptions()' constructor.
+    If the 'OMP_NUM_THREADS' environment variable is set, the 'inter_op_num_threads' and 'intra_op_num_threads' options of 'sess_opts' are set to its value if they are using the default value of 0.
 
     Parameters:
         model_name (str): The name of the model.
+        sess_opts (Optional[ort.SessionOptions]): The ONNX runtime session options. If not provided, a new instance is created.
         *args: Additional positional arguments.
         **kwargs: Additional keyword arguments.
 
@@ -38,11 +39,14 @@ def new_session(model_name: str = "u2net", *args, **kwargs) -> BaseSession:
     if session_class is None:
         raise ValueError(f"No session class found for model '{model_name}'")
 
-    sess_opts = ort.SessionOptions()
+    if sess_opts is None:
+        sess_opts = ort.SessionOptions()
 
     if "OMP_NUM_THREADS" in os.environ:
         threads = int(os.environ["OMP_NUM_THREADS"])
-        sess_opts.inter_op_num_threads = threads
-        sess_opts.intra_op_num_threads = threads
+        if sess_opts.inter_op_num_threads == 0:
+            sess_opts.inter_op_num_threads = threads
+        if sess_opts.intra_op_num_threads == 0:
+            sess_opts.intra_op_num_threads = threads
 
     return session_class(model_name, sess_opts, *args, **kwargs)

--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -11,7 +11,7 @@ def new_session(
     model_name: str = "u2net",
     *args,
     sess_opts: Optional[ort.SessionOptions] = None,
-    **kwargs
+    **kwargs,
 ) -> BaseSession:
     """
     Create a new session object based on the specified model name.

--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -5,7 +5,6 @@ import onnxruntime as ort
 
 from .sessions import sessions_class
 from .sessions.base import BaseSession
-from .sessions.u2net import U2netSession
 
 
 def new_session(model_name: str = "u2net", *args, sess_opts: Optional[ort.SessionOptions] = None, **kwargs) -> BaseSession:

--- a/rembg/session_factory.py
+++ b/rembg/session_factory.py
@@ -7,7 +7,12 @@ from .sessions import sessions_class
 from .sessions.base import BaseSession
 
 
-def new_session(model_name: str = "u2net", *args, sess_opts: Optional[ort.SessionOptions] = None, **kwargs) -> BaseSession:
+def new_session(
+    model_name: str = "u2net",
+    *args,
+    sess_opts: Optional[ort.SessionOptions] = None,
+    **kwargs
+) -> BaseSession:
     """
     Create a new session object based on the specified model name.
 


### PR DESCRIPTION
Allow callers to provide custom ONNX Runtime SessionOptions while preserving the existing OMP_NUM_THREADS behavior for unset thread counts. Explicit values in sess_opts take precedence over environment-derived defaults.

This is useful for more advanced configurations and tuning.